### PR TITLE
asciify-pixel-matrix 1.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 
-# asciify-pixel-matrix [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/asciify-pixel-matrix.svg)](https://www.npmjs.com/package/asciify-pixel-matrix) [![Downloads](https://img.shields.io/npm/dt/asciify-pixel-matrix.svg)](https://www.npmjs.com/package/asciify-pixel-matrix) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# asciify-pixel-matrix
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/asciify-pixel-matrix.svg)](https://www.npmjs.com/package/asciify-pixel-matrix) [![Downloads](https://img.shields.io/npm/dt/asciify-pixel-matrix.svg)](https://www.npmjs.com/package/asciify-pixel-matrix) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > Asciifies a matrix of pixels.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asciify-pixel-matrix",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Asciifies a matrix of pixels.",
   "main": "lib/index.js",
   "directories": {
@@ -37,6 +37,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
